### PR TITLE
Fix kmalloc-induced iounmap-bug.

### DIFF
--- a/Dragon_PCI/PCI/MEM/dragon_pci_mem.c
+++ b/Dragon_PCI/PCI/MEM/dragon_pci_mem.c
@@ -202,7 +202,7 @@ static int dragon_pci_mem_probe(struct pci_dev *dev, const struct pci_device_id 
   printk(KERN_INFO "dragon_pci_mem: using major %d and minor %d for this device\n", major, minor);
 
   /* Allocate a private structure and reference it as driver's data */
-  data = (struct dragon_pci_mem_struct *)kmalloc(sizeof(struct dragon_pci_mem_struct), GFP_KERNEL);
+  data = (struct dragon_pci_mem_struct *)kcalloc(1, sizeof(struct dragon_pci_mem_struct), GFP_KERNEL);
   if (data == NULL) {
     printk(KERN_WARNING "dragon_pci_mem: unable to allocate private structure\n");
 

--- a/Dragon_PCI/PCI/Makefile
+++ b/Dragon_PCI/PCI/Makefile
@@ -1,6 +1,6 @@
 SUBDIRS = IO MEM
 
-USER_PROG= dragon_pci_test
+USER_PROG=
 
 
 all: $(USER_PROG)


### PR DESCRIPTION
Usage of kmalloc and subsequent usage of continue on lines 238 and 241
leaves part of the pointers in data->mmio on uninitialized, non-NULL
values. When iterated over with iounmap on line 295 and line 315, this
calls iounmap on invalid pointers, worst case causing a kernel oops.
Using kcalloc fixes this problem.